### PR TITLE
Changed adb parameter order

### DIFF
--- a/lib/device_api/adb.rb
+++ b/lib/device_api/adb.rb
@@ -30,7 +30,7 @@ module DeviceAPI
     end
     
     def self.getprop(serial)
-      result = DeviceAPI::ADB.execute( "adb wait-for-device -s #{serial} shell getprop" )
+      result = DeviceAPI::ADB.execute( "adb -s #{serial} wait-for-device shell getprop" )
       
       raise result.stderr if result.exit != 0
         


### PR DESCRIPTION
Parameter order changed so that 'simpler' parsers can still use it
